### PR TITLE
Added support for remote webroot validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ Note that you can also pass multiple domains with a single document root, which 
 $ wile cert request example.com:/var/www/example.com/ www.example.com
 ```
 
+Storing webroot validation on remote host using SSH (port is optional, defaults to 22):
+```
+$ wile cert request user@host@port:example.com:/var/www/example.com/
+```
+
 You can also increase the default minimal validity time to one week, if you intend on running wile via a weekly cronjob:
 ```
 $ wile cert request --min-valid-time 1w example.com:/var/www/example.com/

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
         'pyOpenSSL',
         'cryptography',
         'setuptools_scm',  # for run-time version-detect
+        'pexpect',
     ],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
When requesting new certificate one can now store webroot validation on
remote host.

Script now takes parameters like: [USER@HOST[@PORT]:]DOMAIN[:WEBROOT].

Added new dependency (pexpext) that is used for opening SSH connection
and sending commands to remote host.

All the changes are backwards compatible.

Please test this before merge so that we can be sure there are no corner
cases.