### PR TITLE
Fix JOSE dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ config = dict(
     ],
     install_requires=[
         'six',
-        'acme >= 0.16.0',
+        'acme >= 0.21.0',
         'click >= 6.0',
         'pyOpenSSL',
         'cryptography',

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ config = dict(
         'cryptography',
         'setuptools_scm',  # for run-time version-detect
         'paramiko',
+        'josepy',
     ],
     tests_require=[
         'backports.tempfile;python_version<"3.0"',

--- a/wile/__init__.py
+++ b/wile/__init__.py
@@ -4,7 +4,7 @@ from functools import partial
 
 import setuptools_scm
 import click
-from acme import jose
+import josepy as jose
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.asymmetric import rsa

--- a/wile/cert.py
+++ b/wile/cert.py
@@ -13,7 +13,7 @@ from OpenSSL import crypto
 from acme import challenges
 from acme import messages
 from acme import errors
-from acme.jose.util import ComparableX509
+from josepy.util import ComparableX509
 
 from . import reg
 from . import argtypes


### PR DESCRIPTION
Starting with ACME version 0.21.0 implementation for JOSE was split out
of ACME library into a separate package named josepy.

Added josepy as a dependency to setup.py and fixed code according to
this changes.

https://pypi.python.org/pypi/josepy
https://github.com/certbot/josepy