### PR TITLE
Fix click version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ config = dict(
     install_requires=[
         'six',
         'acme >= 0.21.0, != 0.22.0',
-        'click >= 6.0',
+        'click >= 6.0, < 7.0',
         'pyOpenSSL',
         'cryptography',
         'setuptools_scm',  # for run-time version-detect


### PR DESCRIPTION
Click version 7 has been released few weeks ago. Wile is not working with click version 7 so we should stick to 6.x.